### PR TITLE
Feat/1 pydantic 데이터 스키마 정의

### DIFF
--- a/scripts/transform/validator.py
+++ b/scripts/transform/validator.py
@@ -1,10 +1,58 @@
+from enum import Enum
 from datetime import date
-from pydantic import BaseModel, Field
+from typing import Optional, List
+from pydantic import BaseModel, Field, HttpUrl
+
+class ProviderType(str, Enum):
+    LOCAL_GOV = "지자체(출자출연기관)"
+    PUBLIC_ORG = "공공기관"
+    ETC = "기타"
+
+class ProductType(str, Enum):
+    SCHOLARSHIP = "장학금"
+    LOAN = "학자금"
+
+class ScholarshipCategory(str, Enum):
+    LOCAL = "지역연고"
+    SPECIALTY = "특기자"
+    GRADE = "성적우수"
+    INCOME = "소득구분"
+    DISABILITY = "장애인"
+    ETC = "기타"
+    NONE = "해당없음"
 
 class Scholarship(BaseModel):
     """DB에 저장될 최종 장학금 데이터의 스키마(규칙)를 정의합니다."""
     
-    # TODO: 프로젝트에 필요한 필드들 정의
+    id: int = Field(..., alias="번호")
+    product_name: str = Field(..., alias="상품명")
+    provider_name: str = Field(..., alias="운영기관명")
+
+    provider_type: ProviderType = Field(..., alias="운영기관구분")
+    product_type: ProductType = Field(..., alias="상품구분")
+    scholarship_category: ScholarshipCategory = Field(..., alias="학자금유형구분")
+
+    university_category: Optional[List[str]] = Field(None, alias="대학구분")
+    grade_category: Optional[List[str]] = Field(None, alias="학년구분")
+    department_category: Optional[List[str]] = Field(None, alias="학과구분")
+
+    grade_criteria_detail: Optional[str] = Field(None, alias="성적기준 상세내용")
+    income_criteria_detail: Optional[str] = Field(None, alias="소득기준 상세내용")
+    support_detail: Optional[str] = Field(None, alias="지원내역 상세내용")
+    specific_qualification_detail: Optional[str] = Field(None, alias="특정자격 상세내용")
+    residence_requirement_detail: Optional[str] = Field(None, alias="지역거주여부 상세내용")
+    selection_method_detail: Optional[str] = Field(None, alias="선발방법 상세내용")
+    selection_personnel_detail: Optional[str] = Field(None, alias="선발인원 상세내용")
+    qualification_restriction_detail: Optional[str] = Field(None, alias="자격제한 상세내용")
+    recommendation_needed_detail: Optional[str] = Field(None, alias="추천필요여부 상세내용")
+    required_documents_detail: Optional[str] = Field(None, alias="제출서류 상세내용")
+
+    homepage_url: Optional[HttpUrl] = Field(None, alias="홈페이지 주소")
+
+    class Config:
+        populate_by_name = True # alias를 기준으로 데이터를 받음
+        extra = 'ignore'      # 모델에 정의되지 않은 추가 필드는 무시
+        use_enum_values = True  # Enum 값을 기준으로 데이터를 처리
 
 # 이 파일은 다른 파일에서 import하여 사용됩니다.
 if __name__ == "__main__":
@@ -20,5 +68,5 @@ if __name__ == "__main__":
     scholarship_instance = Scholarship(**sample_data)
     
     # 생성된 인스턴스 출력
-    print("✅ Pydantic 모델 테스트 성공:")
+    print("Pydantic 모델 테스트 성공:")
     print(scholarship_instance)

--- a/scripts/transform/validator.py
+++ b/scripts/transform/validator.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from datetime import date
-from typing import Optional, List
+from typing import Optional, List, Dict
 from pydantic import BaseModel, Field, HttpUrl
 
 class ProviderType(str, Enum):
@@ -87,17 +87,38 @@ class Scholarship(BaseModel):
 
 # 이 파일은 다른 파일에서 import하여 사용됩니다.
 if __name__ == "__main__":
-    # 샘플 데이터
-    sample_data = {
-        "title": "기본 장학금",
-        "provider": "기본 재단",
-        "amount": 1000000,
-        "end_date": "2025-09-30"
-    }
+    import sys
+    import os
     
-    # 샘플 데이터로 모델 인스턴스 생성
-    scholarship_instance = Scholarship(**sample_data)
+    # 현재 파일의 경로를 기준으로 프로젝트 루트 경로를 계산하여 sys.path에 추가
+    project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    sys.path.append(project_root)
     
-    # 생성된 인스턴스 출력
-    print("Pydantic 모델 테스트 성공:")
-    print(scholarship_instance)
+    from scripts.ingest.openapi_collector import collect_data
+    import logging
+
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    logger.info("API로부터 실제 데이터를 가져와 테스트를 시작합니다...")
+    
+    # 데이터 수집 함수 호출
+    raw_scholarship_list = collect_data(page=1) 
+
+    # 첫 번째 항목으로 테스트
+    if raw_scholarship_list:
+        logger.info(f"총 {len(raw_scholarship_list)}개의 데이터를 받아왔습니다. 첫 번째 항목으로 검증을 시도합니다.")
+        first_item = raw_scholarship_list[0]
+        
+        try:
+            # Pydantic 모델 검증
+            scholarship_instance = Scholarship.model_validate(first_item)
+            
+            logger.info("Pydantic 모델 실제 데이터 검증 성공!")
+            # 검증된 데이터 JSON 형태로 출력
+            print(scholarship_instance.model_dump_json(indent=2, by_alias=True))
+
+        except Exception as e:
+            logger.error(f" Pydantic 모델 실제 데이터 검증 실패:\n{e}")
+    else:
+        logger.error("API로부터 데이터를 가져오는 데 실패했습니다.")

--- a/scripts/transform/validator.py
+++ b/scripts/transform/validator.py
@@ -24,18 +24,49 @@ class ScholarshipCategory(str, Enum):
 class Scholarship(BaseModel):
     """DB에 저장될 최종 장학금 데이터의 스키마(규칙)를 정의합니다."""
     
+    # --- 필수 정보 ---
     id: int = Field(..., alias="번호")
     product_name: str = Field(..., alias="상품명")
     provider_name: str = Field(..., alias="운영기관명")
-
     provider_type: ProviderType = Field(..., alias="운영기관구분")
     product_type: ProductType = Field(..., alias="상품구분")
     scholarship_category: ScholarshipCategory = Field(..., alias="학자금유형구분")
 
-    university_category: Optional[List[str]] = Field(None, alias="대학구분")
-    grade_category: Optional[List[str]] = Field(None, alias="학년구분")
-    department_category: Optional[List[str]] = Field(None, alias="학과구분")
+    # --- 날짜 및 URL 정보 ---
+    application_start_date: date = Field(..., alias="모집시작일")
+    application_end_date: date = Field(..., alias="모집종료일")
+    homepage_url: Optional[HttpUrl] = Field(None, alias="홈페이지 주소")
 
+    # --- 원본 텍스트 가공하여 채울 구조화된 필드 ---
+
+    # 가공 후 List[str] 정보
+    university_category: List[str] = Field(default_factory=list, description="대학 구분 목록 (처리 후)")
+    grade_category: List[str] = Field(default_factory=list, description="학년 구분 목록 (처리 후)")
+    department_category: List[str] = Field(default_factory=list, description="학과 구분 목록 (처리 후)")
+
+    # '지원내역 상세내용'에서 추출
+    
+    # '선발인원 상세내용'에서 추출
+    num_of_recipients_total: Optional[int] = Field(None, description="총 선발 인원(숫자). '12명' -> 12")
+    recipients_by_category: Optional[Dict[str, int]] = Field(None, description="구분별 선발 인원. '4년제 36명' -> {'4년제': 36}")
+    num_notes: Optional[str] = Field(None, description="선발 인원 관련 비고 (예: 약간 명, 각 학교당 1명)")
+
+    # '성적기준 상세내용'에서 추출
+    
+    # '추천필요여부 상세내용'에서 추출
+    is_recommendation_required: bool = Field(False, description="추천서 필요 여부")
+
+    # '자격제한 상세내용'에서 추출
+    is_duplicate_support_restricted: bool = Field(False, description="타 장학금 중복수혜 제한 여부")
+    
+    # '특정자격 상세내용', '자격제한 상세내용' 등에서 키워드 추출
+    qualification_tags: List[str] = Field(default_factory=list, description="자격 요건 키워드 태그 (예: ['다문화', '경영학과'])")
+
+
+    # --- 참고용 원본 텍스트 필드 (추후 필요 여부 확인 후 삭제 가능) ---
+    university_category_str: Optional[str] = Field(None, alias="대학구분")
+    grade_category_str: Optional[str] = Field(None, alias="학년구분")
+    department_category_str: Optional[str] = Field(None, alias="학과구분")
     grade_criteria_detail: Optional[str] = Field(None, alias="성적기준 상세내용")
     income_criteria_detail: Optional[str] = Field(None, alias="소득기준 상세내용")
     support_detail: Optional[str] = Field(None, alias="지원내역 상세내용")
@@ -47,7 +78,7 @@ class Scholarship(BaseModel):
     recommendation_needed_detail: Optional[str] = Field(None, alias="추천필요여부 상세내용")
     required_documents_detail: Optional[str] = Field(None, alias="제출서류 상세내용")
 
-    homepage_url: Optional[HttpUrl] = Field(None, alias="홈페이지 주소")
+    
 
     class Config:
         populate_by_name = True # alias를 기준으로 데이터를 받음


### PR DESCRIPTION
## ✨ 변경 사항
- Pydantic을 이용한 초기 데이터 스키마 정의 : Open API 응답 명세에 맞춰 Scholarship 데이터 모델의 기본 구조와 타입 정의
- 지정된 값은 Enum 필드 정의하여 관리
- 상세 내용 필드 구조화 : 비정형 텍스트로 제공되는 상세내용 필드에서 유의미한 정보를 추출하여 저장할 수 있도록 구조화된 필드 추가 (추가적인 필드 정의 필요)
- 가공 전 원본 텍스트 필드 (..._str)와 가공 후 데이터 필드 분리 설계
- Open API로 받아온 실제 데이터를 통해 validator 테스트

## 🔄 연관 이슈
- #1 

## ✅ 체크리스트
- [x] 코드 빌드/테스트 통과
- [x] 문서·주석 업데이트

## 📖 기타
상세 내용 필드 구조화 추가 작업 필요
데이터 가공 로직은 transformer.py를 통해 구현될 예정